### PR TITLE
[RA-4567] Affected files root cause verification

### DIFF
--- a/src/elastio-snap.c
+++ b/src/elastio-snap.c
@@ -888,10 +888,12 @@ static void bio_free_pages(struct bio *bio){
  * be defined and equal to the 2 bits.
  */
 #define __ELASTIO_SNAP_PASSTHROUGH 28	// set as the last flag bit
+#define __ELASTIO_SNAP_REQ_DRV    27
 #else
 // set as an unused flag in versions older than 4.8
 // set as an unused opcode bit in kernels newer than 4.9
 #define __ELASTIO_SNAP_PASSTHROUGH 30
+#define __ELASTIO_SNAP_REQ_DRV    29
 #endif
 #define ELASTIO_SNAP_PASSTHROUGH (1ULL << __ELASTIO_SNAP_PASSTHROUGH)
 
@@ -902,6 +904,11 @@ static void bio_free_pages(struct bio *bio){
 #define BIO_MAX_PAGES BIO_MAX_VECS
 #endif
 
+#ifndef REQ_DRV
+// was added in v4.15
+#define REQ_DRV (1U << __ELASTIO_SNAP_REQ_DRV)
+#endif
+
 //global module parameters
 static int elastio_snap_may_hook_syscalls = 0;
 static unsigned long elastio_snap_cow_ext_buf_size = sizeof(struct fiemap_extent) * 1024;
@@ -909,6 +916,7 @@ static unsigned long elastio_snap_cow_max_memory_default = (300 * 1024 * 1024);
 static unsigned int elastio_snap_cow_fallocate_percentage_default = 10;
 static unsigned int elastio_snap_max_snap_devices = ELASTIO_SNAP_DEFAULT_SNAP_DEVICES;
 static int elastio_snap_debug = 0;
+static int elastio_snap_read_lock = 0;
 
 module_param_named(may_hook_syscalls, elastio_snap_may_hook_syscalls, int, S_IRUGO);
 MODULE_PARM_DESC(may_hook_syscalls, "if true, allows the kernel module to find and alter the system call table to allow tracing to work across remounts");
@@ -927,6 +935,9 @@ MODULE_PARM_DESC(max_snap_devices, "maximum number of tracers available");
 
 module_param_named(debug, elastio_snap_debug, int, S_IRUGO | S_IWUSR);
 MODULE_PARM_DESC(debug, "enables debug logging");
+
+module_param_named(read_lock, elastio_snap_read_lock, int, S_IRUGO | S_IWUSR);
+MODULE_PARM_DESC(read_lock, "holds write operations during the snapshot reading");
 
 /*********************************STRUCT DEFINITIONS*******************************/
 
@@ -3724,17 +3735,25 @@ static int snap_mrf_thread(void *data){
 		//wait for a bio to process or a kthread_stop call
 		wait_event_interruptible(bq->event, kthread_should_stop() || !bio_queue_empty(bq));
 		if(bio_queue_empty(bq)) continue;
+		if (elastio_snap_read_lock) {
+			cond_resched();
+			continue;
+		}
 
 		//safely dequeue a bio
 		bio = bio_queue_dequeue(bq);
 
-		//submit the original bio to the block IO layer
-		elastio_snap_bio_op_set_flag(bio, ELASTIO_SNAP_PASSTHROUGH);
-
-		ret = elastio_snap_call_mrf(dev->sd_orig_mrf, bio);
+		if (!elastio_snap_bio_op_flagged(bio, REQ_DRV)) {
+			//submit the original bio to the block IO layer
+			elastio_snap_bio_op_set_flag(bio, ELASTIO_SNAP_PASSTHROUGH);
+			ret = elastio_snap_call_mrf(dev->sd_orig_mrf, bio);
 #ifdef HAVE_MAKE_REQUEST_FN_INT
-		if(ret) generic_make_request(bio);
+			if(ret) generic_make_request(bio);
 #endif
+		} else {
+			// submit it back to tracing_mrf
+			elastio_snap_submit_bio(bio);
+		}
 	}
 
 	return 0;
@@ -4171,7 +4190,19 @@ static MRF_RETURN_TYPE tracing_mrf(struct request_queue *q, struct bio *bio){
 		}
 
 		if(tracer_should_trace_bio(dev, bio)){
-			if(test_bit(SNAPSHOT, &dev->sd_state)) ret = snap_trace_bio(dev, bio);
+
+			if(test_bit(SNAPSHOT, &dev->sd_state)) {
+				if (!elastio_snap_bio_op_flagged(bio, REQ_DRV)) {
+					elastio_snap_bio_op_set_flag(bio, REQ_DRV);
+					bio_queue_add(&dev->sd_orig_bios, bio);
+					goto out;
+				} else {
+					// bio returned from the queue
+					elastio_snap_bio_op_clear_flag(bio, REQ_DRV);
+				}
+
+				ret = snap_trace_bio(dev, bio);
+			}
 			else ret = inc_trace_bio(dev, bio);
 			goto out;
 		}


### PR DESCRIPTION
It is suspected that the race condition may affect file system integrity during the snapshot process. As a verification of that
theory, an additional possibility of suspending write bio requests has been implemented. From now on, after mounting the
snapshot device and before snapshot reading, we can temporarily suspend bio requests by acquiring a 'read lock' with the
following command:

```
sudo bash -c 'echo '1' > /sys/module/elastio_snap/parameters/read_lock'
```
[Snapshot reading takes place here]

```
sudo bash -c 'echo '0' > /sys/module/elastio_snap/parameters/read_lock'
```

After the last command, all write bio requests will be flushed.

If the assumption about the race condition is correct, we should see the reproduction ratio decrease or the bug disappear.

Note: this should be merged after reverting the snapshot debug functionality in PR #41.