### PR TITLE
[RA-4971] Implement support of Linux kernel v6.7

### DIFF
--- a/src/configure-tests/feature-tests/get_super.c
+++ b/src/configure-tests/feature-tests/get_super.c
@@ -1,0 +1,15 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+/*
+ * Copyright (C) 2024 Axcient Inc.
+ */
+
+// kernel_version < 6.7
+
+#include "includes.h"
+MODULE_LICENSE("GPL");
+
+static inline void dummy(void){
+	struct block_device *bdev = NULL;
+	get_super(bdev);
+}

--- a/src/configure-tests/symbol-tests
+++ b/src/configure-tests/symbol-tests
@@ -11,6 +11,7 @@ kfree
 blk_mq_submit_bio
 blk_alloc_queue
 get_super
+user_get_super
 vm_area_alloc
 vm_area_free
 insert_vm_struct

--- a/src/elastio-snap.c
+++ b/src/elastio-snap.c
@@ -143,11 +143,20 @@ struct request_queue* (*elastio_blk_alloc_queue)(int node_id) = (BLK_ALLOC_QUEUE
 	(struct request_queue* (*)(int node_id)) (BLK_ALLOC_QUEUE_ADDR + (long long)(((void *)kfree) - (void *)KFREE_ADDR)) : NULL;
 #endif
 
-struct super_block* (*elastio_snap_get_super)(struct block_device *) = (GET_SUPER_ADDR != 0) ?
+struct super_block* (*__elastio_snap_get_super)(struct block_device *) = (GET_SUPER_ADDR != 0) ?
 	(struct super_block* (*)(struct block_device*)) (GET_SUPER_ADDR + (long long)(((void *)kfree) - (void *)KFREE_ADDR)) : NULL;
 
-struct super_block* (*elastio_snap_user_get_super)(dev_t, bool) = (USER_GET_SUPER_ADDR != 0) ?
+struct super_block* (*__elastio_snap_user_get_super)(dev_t, bool) = (USER_GET_SUPER_ADDR != 0) ?
 	(struct super_block* (*)(dev_t, bool)) (USER_GET_SUPER_ADDR + (long long)(((void *)kfree) - (void *)KFREE_ADDR)) : NULL;
+
+struct super_block *elastio_snap_get_super(struct block_device *bdev)
+{
+#ifdef HAVE_GET_SUPER
+	return __elastio_snap_get_super(bdev);
+#else
+	return __elastio_snap_user_get_super(bdev->bd_dev, false);
+#endif
+}
 
 #if !(defined HAVE_BLKDEV_GET_BY_PATH || defined HAVE_BLKDEV_GET_BY_PATH_4)
 struct block_device *elastio_snap_lookup_bdev(const char *pathname, fmode_t mode) {
@@ -4408,11 +4417,7 @@ static int __tracer_transition_tracing(struct snap_device *dev, struct block_dev
 static int __tracer_transition_tracing(struct snap_device *dev, struct block_device *bdev, const struct block_device_operations *new_ops, struct snap_device **dev_ptr, bool start){
 #endif
 	int ret;
-#ifdef HAVE_GET_SUPER
 	struct super_block *origsb = elastio_snap_get_super(bdev);
-#else
-	struct super_block *origsb = elastio_snap_user_get_super(bdev->bd_dev, false);
-#endif
 #ifdef HAVE_THAW_BDEV_INT
 	struct super_block *sb = NULL;
 #endif
@@ -4644,12 +4649,7 @@ static int __tracer_destroy_cow(struct snap_device *dev, int close_method){
 
 
 static int file_is_on_bdev(const struct file *file, struct block_device *bdev) {
-#ifdef HAVE_GET_SUPER
 	struct super_block *sb = elastio_snap_get_super(bdev);
-#else
-	struct super_block *sb = elastio_snap_user_get_super(bdev->bd_dev, false);
-#endif
-
 	int ret = 0;
 	if (sb) {
 		ret = ((elastio_snap_get_mnt(file))->mnt_sb == sb);
@@ -5452,11 +5452,7 @@ static int __verify_bdev_writable(const char *bdev_path, int *out){
 		return PTR_ERR(bdev);
 	}
 
-#ifdef HAVE_GET_SUPER
 	sb = elastio_snap_get_super(bdev);
-#else
-	sb = elastio_snap_user_get_super(bdev->bd_dev, false);
-#endif
 	if(sb){
 		writable = !(sb->s_flags & MS_RDONLY);
 		drop_super(sb);
@@ -6148,11 +6144,7 @@ static void post_umount_check(int dormant_ret, long umount_ret, unsigned int idx
 	task_work_flush();
 
 	//if we went dormant, but the block device is still mounted somewhere, goto fail state
-#ifdef HAVE_GET_SUPER
 	sb = elastio_snap_get_super(dev->sd_base_dev);
-#else
-	sb = elastio_snap_user_get_super(dev->sd_base_dev->bd_dev, false);
-#endif
 	if(sb){
 		if(!(sb->s_flags & MS_RDONLY)){
 			LOG_ERROR(-EIO, "device still mounted after umounting cow file's file-system. entering error state");


### PR DESCRIPTION
The `get_super()` function has been removed in the recent Linux kernel version. Switched it to `user_get_super()` and added the relevant compat.