### PR TITLE
[RA-4977] Hide UUID&FS_TYPE for snapshot on CentOS/RadHat7

### DIFF
--- a/dist/udev/61-nopersistant-elastio.rules
+++ b/dist/udev/61-nopersistant-elastio.rules
@@ -1,0 +1,3 @@
+# Skip elastio devices from creating persistant links.
+# Overwrite 60-persistent-storage.rules
+KERNEL=="elastio-snap*", ENV{ID_FS_TYPE}:="", ENV{ID_FS_UUID_ENC}:=""


### PR DESCRIPTION
On Redhat/CentOS 7:
```
[root@localhost user]# lsblk -f
NAME            FSTYPE      LABEL UUID                                   MOUNTPOINT
sda
├─sda1          vfat              8ECE-75EF                              /boot/efi
├─sda2          xfs               e6dbc90a-e035-40e6-9c18-59c720968c2e   /boot
└─sda3          LVM2_member       d6C3CP-BCUd-NSAv-Tn9e-zRN0-GdyT-hhya00
  ├─centos-root xfs               208e17d4-2a5c-42b2-b6b4-13db113cf01f   /
  └─centos-swap swap              fab81408-e32f-4add-a110-645cd7b65cbd   [SWAP]
sr0
elastio-snap0   xfs               e6dbc90a-e035-40e6-9c18-59c720968c2e //!<<< 
```

After this patch will as on Redhat/CentOS >= 8:
```
[root@localhost user]# lsblk -f
NAME            FSTYPE      LABEL UUID                                   MOUNTPOINT
sda
├─sda1          vfat              8ECE-75EF                              /boot/efi
├─sda2          xfs               e6dbc90a-e035-40e6-9c18-59c720968c2e   /boot
└─sda3          LVM2_member       d6C3CP-BCUd-NSAv-Tn9e-zRN0-GdyT-hhya00
  ├─centos-root xfs               208e17d4-2a5c-42b2-b6b4-13db113cf01f   /
  └─centos-swap swap              fab81408-e32f-4add-a110-645cd7b65cbd   [SWAP]
sr0
elastio-snap0
```
