### PR TITLE
[RA-4977] Hide UUID&FS_TYPE for snapshot on CentOS/RadHat7 (#54)

### DIFF
--- a/dist/udev/61-nopersistant-elastio.rules
+++ b/dist/udev/61-nopersistant-elastio.rules
@@ -1,0 +1,3 @@
+# Skip elastio devices from creating persistant links.
+# Overwrite 60-persistent-storage.rules
+KERNEL=="elastio-snap*", ENV{ID_FS_TYPE}:="", ENV{ID_FS_UUID_ENC}:=""


### PR DESCRIPTION
Skip elastio devices from creating persistent links and overwrite 60-persistent-storage.rules