### PR TITLE
[RA-4567] Enable Netlink debug

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -3,7 +3,7 @@
 obj-m := elastio-snap.o
 elastio-snap-objs:= main.o
 
-NETLINK_DEBUG=y
+NETLINK_DEBUG ?= y
 
 ifeq ($(NETLINK_DEBUG),y)
 elastio-snap-objs += nl_debug.o

--- a/src/Makefile
+++ b/src/Makefile
@@ -3,7 +3,13 @@
 obj-m := elastio-snap.o
 elastio-snap-objs:= main.o
 
+KVER=$(shell uname -r)
+KMAJ = $(shell echo $(KVER) | \
+sed -e 's/^\([0-9][0-9]*\)\.[0-9][0-9]*\.[0-9][0-9]*.*/\1/')
+
+ifeq ($(shell test $(KMAJ) -gt 3; echo $$?),0)
 NETLINK_DEBUG ?= y
+endif
 
 ifeq ($(NETLINK_DEBUG),y)
 elastio-snap-objs += nl_debug.o

--- a/src/Makefile
+++ b/src/Makefile
@@ -3,6 +3,8 @@
 obj-m := elastio-snap.o
 elastio-snap-objs:= main.o
 
+NETLINK_DEBUG=y
+
 ifeq ($(NETLINK_DEBUG),y)
 elastio-snap-objs += nl_debug.o
 endif

--- a/src/main.c
+++ b/src/main.c
@@ -3044,6 +3044,9 @@ static int cow_read_mapping(struct cow_manager *cm, uint64_t pos, uint64_t *out)
 	if(!cm->sects[sect_idx].mappings){
 		if(!cm->sects[sect_idx].has_data){
 			*out = 0;
+#ifdef NETLINK_DEBUG
+			nl_trace_event_cow(NL_EVENT_COW_READ_MAPPING, pos, *out);
+#endif
 			return 0;
 		}else{
 			ret = __cow_load_section(cm, sect_idx);

--- a/src/nl_debug.c
+++ b/src/nl_debug.c
@@ -22,7 +22,6 @@ int nl_send_event(enum nl_msg_type type, const char *func, int line, struct nl_p
 	NETLINK_CB(skb).portid = 0;
 	NETLINK_CB(skb).dst_group = NL_MCAST_GROUP;
 
-	spin_lock_bh(&nl_spinlock);
 	msg = nlmsg_data(nlsk_mh);
 	msg->type = type;
 	ktime_get_ts64(&tspec);
@@ -38,7 +37,6 @@ int nl_send_event(enum nl_msg_type type, const char *func, int line, struct nl_p
 	memcpy(&msg->params, params, sizeof(*params));
 
 	nlmsg_multicast(nl_sock, skb, 0, NL_MCAST_GROUP, GFP_ATOMIC);
-	spin_unlock_bh(&nl_spinlock);
 	return 0;
 }
 

--- a/src/nl_debug.c
+++ b/src/nl_debug.c
@@ -15,6 +15,7 @@ int nl_send_event(enum nl_msg_type type, const char *func, int line, struct nl_p
 	struct sk_buff *skb;
 	struct nl_msg_header *msg;
 	struct nlmsghdr *nlsk_mh;
+	struct timespec64 tspec;
 
 	skb = nlmsg_new(NLMSG_DEFAULT_SIZE, GFP_ATOMIC);
 	nlsk_mh = nlmsg_put(skb, 0, 0, NLMSG_DONE, sizeof(struct nl_msg_header), 0);
@@ -24,7 +25,8 @@ int nl_send_event(enum nl_msg_type type, const char *func, int line, struct nl_p
 	spin_lock_bh(&nl_spinlock);
 	msg = nlmsg_data(nlsk_mh);
 	msg->type = type;
-	msg->timestamp = ktime_get();
+	ktime_get_ts64(&tspec);
+	msg->timestamp = timespec64_to_ns(&tspec);
 	msg->seq_num = seq_num;
 	seq_num++;
 


### PR DESCRIPTION
Enabled the Netlink debug to verify how exactly the COW file is handled for the corrupted files