### PR TITLE
[RA-5171] Remove all versions dkms before install new version

### DIFF
--- a/dist/elastio-snap.spec
+++ b/dist/elastio-snap.spec
@@ -429,6 +429,10 @@ install -m 755 dist/udev/* %{buildroot}%{_udev_rules}
 # Get rid of git artifacts
 find %{buildroot} -name "*.git*" -print0 | xargs -0 rm -rfv
 
+%pre -n %{dkmsname}
+dkms status elastio-snap | awk -F'[, /]*' {'print $2'} | xargs -I{} dkms remove -m elastio-snap -v {} --all || :
+rm -rf /var/lib/dkms/elastio-snap/ &> /dev/null || :
+
 %preun -n %{dkmsname}
 
 %if "%{_vendor}" == "debbuild"


### PR DESCRIPTION
We should remove all elastio dkms before install, because sources tree will be changed and will faced with (after upgrade to 0.12.3):
```
root@kg-ubuntu-22-efi:/home/user# dkms status --verbose
Error! Could not locate dkms.conf file.
File: /var/lib/dkms/elastio-snap/0.12.2/source/dkms.conf does not exist.
```
Debian was affected after https://github.com/Axcient/elastio-snap/pull/32