### PR TITLE
[RA-5262] Increase unit tests timeout for Ubuntu 24.04

### DIFF
--- a/tests/util.py
+++ b/tests/util.py
@@ -11,7 +11,7 @@ import subprocess
 import sys
 import time
 
-TIMEOUT_SCALE = 2
+TIMEOUT_SCALE = 3
 
 
 def mount(device, path, opts=None):


### PR DESCRIPTION
TIMEOUT_SCALE has been increased in the unit tests