### PR TITLE
[RA-5286] Add RedHat distributions to the CI pipeline

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -63,7 +63,8 @@ pipeline
 							'centos7', 'centos8', 'centos9',
 							'alma8', 'alma9',
 							'fedora31', 'fedora32', 'fedora34', 'fedora35', 'fedora36', 'fedora37', 'fedora38', 'fedora39',
-							'ubuntu1804', 'ubuntu2004', 'ubuntu2204', 'ubuntu2404'
+							'ubuntu1804', 'ubuntu2004', 'ubuntu2204', 'ubuntu2404',
+							'rhel8', 'rhel9'
 					}
 				}
 				agent {


### PR DESCRIPTION
RHEL8 and RHEL9 have been added to the pipeline