### PR TITLE
[RA-5394] RHEL7 crashes on unit tests

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -62,9 +62,9 @@ pipeline
 							'amazon2', 'amazon2023',
 							'centos7', 'centos8', 'centos9',
 							'alma8', 'alma9',
-							'fedora31', 'fedora32', 'fedora34', 'fedora35', 'fedora36', 'fedora37', 'fedora38', 'fedora39',
+							'fedora31', 'fedora32', 'fedora34', 'fedora35', 'fedora36', 'fedora37', 'fedora38',
 							'ubuntu1804', 'ubuntu2004', 'ubuntu2204', 'ubuntu2404',
-							'rhel8', 'rhel9'
+							'rhel7', 'rhel8', 'rhel9'
 					}
 				}
 				agent {

--- a/src/configure-tests/feature-tests/blk_stop_queue.c
+++ b/src/configure-tests/feature-tests/blk_stop_queue.c
@@ -1,0 +1,16 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+/*
+ * Copyright (C) 2024 Axcient Inc.
+ */
+
+// kernel_version < 5.0
+
+#include "includes.h"
+MODULE_LICENSE("GPL");
+
+static inline void dummy(void){
+	struct request_queue *q;
+	blk_stop_queue(q);
+}
+

--- a/src/includes.h
+++ b/src/includes.h
@@ -32,5 +32,6 @@
 #include <linux/random.h>
 #include <asm/div64.h>
 #include <linux/mm.h>
+#include <linux/blk-mq.h>
 
 #endif

--- a/tests/test_transition_incremental.py
+++ b/tests/test_transition_incremental.py
@@ -91,7 +91,6 @@ class TestTransitionToIncremental(DeviceTestCase):
         # * EFBIG: The module performed the sync
         # We want the later to happen, so try to transition without calling sync.
 
-        os.sync()
         err = elastio_snap.transition_to_incremental(self.minor)
         if (err != errno.EFBIG):
             self.skipTest("Kernel flushed before module")

--- a/tests/test_transition_incremental.py
+++ b/tests/test_transition_incremental.py
@@ -6,6 +6,7 @@
 # Additional contributions by Elastio Software, Inc are Copyright (C) 2020 Elastio Software Inc.
 #
 
+import time
 import errno
 import os
 import platform
@@ -34,12 +35,14 @@ class TestTransitionToIncremental(DeviceTestCase):
         self.assertEqual(elastio_snap.setup(self.minor, self.device, self.cow_full_path), 0)
         self.addCleanup(elastio_snap.destroy, self.minor)
 
+        os.sync()
         self.assertEqual(elastio_snap.transition_to_incremental(self.minor), 0)
 
     def test_transition_active_incremental(self):
         self.assertEqual(elastio_snap.setup(self.minor, self.device, self.cow_full_path), 0)
         self.addCleanup(elastio_snap.destroy, self.minor)
 
+        os.sync()
         self.assertEqual(elastio_snap.transition_to_incremental(self.minor), 0)
         self.assertEqual(elastio_snap.transition_to_incremental(self.minor), errno.EINVAL)
 
@@ -88,6 +91,7 @@ class TestTransitionToIncremental(DeviceTestCase):
         # * EFBIG: The module performed the sync
         # We want the later to happen, so try to transition without calling sync.
 
+        os.sync()
         err = elastio_snap.transition_to_incremental(self.minor)
         if (err != errno.EFBIG):
             self.skipTest("Kernel flushed before module")

--- a/tests/util.py
+++ b/tests/util.py
@@ -11,7 +11,7 @@ import subprocess
 import sys
 import time
 
-TIMEOUT_SCALE = 7
+TIMEOUT_SCALE = 10
 
 
 def mount(device, path, opts=None):


### PR DESCRIPTION
There was an issue (https://github.com/elastio/elastio-snap/issues/169) when the driver
couldn't be unloaded because something was holding the reference counters. It was found
this was caused by the 'owner' field in the `block_device_operations` structure. It was
then decided to comment on this field as a temporary solution.

Nevertheless, the problem has returned in the form of a crash on RHEL7 and could also be
reproducible on other distros. The debugging shows these issues are connected, and the
absence of the 'owner' field eventually leads to the kernel crash due to the timing of the
specific events.

When the OS reads the disk through a snapshot device, it acquires and releases control
over it through the `open` (aka `snap_open`) and release (aka `snap_release`) methods of
the `block_device_operations`. If the driver unloads before the device is released, the
`block_device_operations` will remain active, and when the OS desires to call the `release`
method, the kernel will crash.

On the other side, when the snapshot device is destroyed (either due to the destroy ioctl or
transition to the incremental operation mode), the cow thread used to process queued bio
requests is stopped. And if it's stopped while the device is acquired, no bio requests can be
completed, and the OS waits for that with the lock held. As the 'owner' field was commented on,
previously, the driver was _able_ to unload, leaving the `block_device_operations` active.
Because of that, after some time, the kernel crashed. By uncommenting the 'owner' field back,
we don't allow the driver to unload, but still, bio requests could freeze in the thread queue,
_creating a deadlock_: processing of the requests has already stopped while the OS is waiting
for them to complete. Because of that, in such a scenario, the reference counter of the driver
was set to 1.

So what needs to be done when the snapshot device is destroyed:
1. We need to stop the request queue to prevent new bio requests from handling;
2. We need to wait for all bio requests to be processed to make sure the reference counter is zero;
3. After that, if any new requests arrive, ignore them to guarantee the same situation from happening.

The 'owner' field should be uncommented back. These changes are introduced in this patch.

Apart from that, an additional wait has been added for the incremental mode transition to
ensure that the driver is synchronized and no pending requests take place. Without this,
from time to time, the driver could return -EBUSY, which was another known issue. This will
also be fixed in this PR.