### PR TITLE
[RA-5502] Implement driver support for v6.10

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -62,7 +62,7 @@ pipeline
 							'amazon2', 'amazon2023',
 							'centos7', 'centos8', 'centos9',
 							'alma8', 'alma9',
-							'fedora31', 'fedora32', 'fedora34', 'fedora35', 'fedora36', 'fedora37', 'fedora38',
+							'fedora31', 'fedora32', 'fedora34', 'fedora35', 'fedora36', 'fedora37', 'fedora38', 'fedora39',
 							'ubuntu1804', 'ubuntu2004', 'ubuntu2204', 'ubuntu2404',
 							'rhel7', 'rhel8', 'rhel9'
 					}

--- a/src/configure-tests/feature-tests/Makefile
+++ b/src/configure-tests/feature-tests/Makefile
@@ -1,6 +1,9 @@
 # SPDX-License-Identifier: GPL-2.0-only
 
-obj-m := $(OBJ)
+SRC=$(TEST_NAME).c
+OBJ=$(TEST_NAME).o
+
+obj-m :=$(OBJ)
 
 KERNELVERSION ?= $(shell uname -r)
 KDIR := /lib/modules/$(KERNELVERSION)/build
@@ -8,6 +11,7 @@ PWD := $(shell pwd)
 EXTRA_CFLAGS := -g -Werror -I$(src)/../..
 BUILDDIR ?= $(PWD)/build/$(OBJ)
 BUILDDIR_MAKEFILE ?= $(PWD)/build/$(OBJ)/Makefile
+BUILDDIR_SOURCE ?= $(PWD)/build/$(OBJ)/$(SRC)
 
 default: $(BUILDDIR_MAKEFILE)
 	$(MAKE) -C $(KDIR) M=$(BUILDDIR) src=$(PWD) modules
@@ -17,6 +21,7 @@ $(BUILDDIR):
 
 $(BUILDDIR_MAKEFILE): $(BUILDDIR)
 	touch "$@"
+	ln -sf $(PWD)/$(SRC) $(BUILDDIR_SOURCE)
 
 clean: $(BUILDDIR)
 	$(MAKE) -C $(KDIR) M=$(BUILDDIR) src=$(PWD) clean

--- a/src/configure-tests/feature-tests/bd_has_submit_bio_flags.c
+++ b/src/configure-tests/feature-tests/bd_has_submit_bio_flags.c
@@ -1,0 +1,13 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+/*
+ * Copyright (C) 2024 Axcient Inc.
+ */
+
+#include "includes.h"
+MODULE_LICENSE("GPL");
+
+static inline void dummy(void){
+	struct block_device *bdev;
+	bdev_set_flag(bdev, BD_HAS_SUBMIT_BIO);
+}

--- a/src/configure-tests/symbol-tests
+++ b/src/configure-tests/symbol-tests
@@ -16,3 +16,4 @@ vm_area_alloc
 vm_area_free
 insert_vm_struct
 vm_area_cachep
+__get_unmapped_area

--- a/src/genconfig.sh
+++ b/src/genconfig.sh
@@ -91,10 +91,9 @@ make -s -C $FEATURE_TEST_DIR clean KERNELVERSION=$KERNEL_VERSION
 
 run_one_test() {
 	local TEST="$(basename $1 .c)"
-	local OBJ="$TEST.o"
 	local MACRO_NAME="HAVE_$(echo ${TEST} | awk '{print toupper($0)}')"
 	local PREFIX="performing configure test: $MACRO_NAME -"
-	if make -C $FEATURE_TEST_DIR OBJ=$OBJ KERNELVERSION=$KERNEL_VERSION &>/dev/null ; then
+	if make -C $FEATURE_TEST_DIR TEST_NAME=$TEST KERNELVERSION=$KERNEL_VERSION &>/dev/null ; then
 		echo "$PREFIX present"
 		echo "#define $MACRO_NAME" >> $OUTPUT_FILE
 	else


### PR DESCRIPTION
* Apparently, starting from v6.10, the source files need to be in the module build directory - handled that with symlinks
* Fixed `get_unmapped_area()`, which is not exported anymore
* `bd_has_submit_bio` moved from the variable to the flag
* Enabled Fedora 39 back