### PR TITLE
[RA-5749] Limit amount of mandatory tests for elastio-snap

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -135,10 +135,7 @@ pipeline
 							branch pattern: '^(build|release|develop|master|staging).*', comparator: "REGEXP"
 							expression { env.DISTRO != 'debian8' }
 						}
-						steps
-						{
-							runTests(supported_fs, " -d ${test_disks[env.DISTRO][0]} -d ${test_disks[env.DISTRO][1]} --raid")
-						}
+						steps { runTests(supported_fs, " -d ${test_disks[env.DISTRO][0]} -d ${test_disks[env.DISTRO][1]} --raid") }
 					}
 
 					stage('Run tests multipart  (qcow2 disks)') {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -46,7 +46,7 @@ pipeline
 				beforeAgent true
 				anyOf
 				{
-					branch pattern: '^(build|release|develop|master|staging).*', comparator: "REGEXP"
+					branch pattern: '^(build|quick-build|release|develop|master|staging).*', comparator: "REGEXP"
 					changeRequest()
 				}
 			}
@@ -114,17 +114,37 @@ pipeline
 					stage('Run tests on LVM (loop device)') { steps { runTests(supported_fs, "--lvm") } }
 					stage('Run tests on RAID (loop device)') { steps { runTests(supported_fs, "--raid") } }
 
-					stage('Run tests (qcow2 disk)') { steps { runTests(supported_fs, "-d ${test_disks[env.DISTRO][0]}1") } }
-					stage('Run tests on LVM (qcow2 disks)') { steps { runTests(supported_fs, " -d ${test_disks[env.DISTRO][0]} -d ${test_disks[env.DISTRO][1]} --lvm") } }
+					stage('Run tests (qcow2 disk)')
+					{
+						when { branch pattern: '^(build|release|develop|master|staging).*', comparator: "REGEXP" }
+						steps { runTests(supported_fs, "-d ${test_disks[env.DISTRO][0]}1") }
+					}
+
+					stage('Run tests on LVM (qcow2 disks)')
+					{
+						when { branch pattern: '^(build|release|develop|master|staging).*', comparator: "REGEXP" }
+						steps { runTests(supported_fs, " -d ${test_disks[env.DISTRO][0]} -d ${test_disks[env.DISTRO][1]} --lvm") }
+					}
+
 					stage('Run tests on RAID (qcow2 disks)')
 					{
 						// An issue is observed in virtio driver whith XFS and kernel 3.16 on Debian 8. It's a known issue, it happens on
 						// mount of the raid1 device with XFS even if elastio-snap is not loaded. See https://bugzilla.redhat.com/show_bug.cgi?id=1111290
-						when { expression { env.DISTRO != 'debian8' } }
-						steps { runTests(supported_fs, " -d ${test_disks[env.DISTRO][0]} -d ${test_disks[env.DISTRO][1]} --raid") }
+						when
+						{
+							branch pattern: '^(build|release|develop|master|staging).*', comparator: "REGEXP"
+							expression { env.DISTRO != 'debian8' }
+						}
+						steps
+						{
+							runTests(supported_fs, " -d ${test_disks[env.DISTRO][0]} -d ${test_disks[env.DISTRO][1]} --raid")
+						}
 					}
 
-					stage('Run tests multipart  (qcow2 disks)') { steps { runTests(supported_fs, "-d ${test_disks[env.DISTRO][0]}  -t test_multipart") } }
+					stage('Run tests multipart  (qcow2 disks)') {
+						when { branch pattern: '^(build|release|develop|master|staging).*', comparator: "REGEXP" }
+						steps { runTests(supported_fs, "-d ${test_disks[env.DISTRO][0]}  -t test_multipart") }
+					}
 				}
 			}
 		}


### PR DESCRIPTION
* From now on, only loop device tests are mandatory for pull requests (quick test set)
* The full test set is applied to the master, develop, staging, build, and release branches
* To trigger the full test set manually, without creating the PR, the build branch may be used
* To trigger a quick test set manually, without creating the PR, the `quick-build` may be used