### PR TITLE
[RA-6158] VM becomes unavailable if the driver has an error on transition-to-incremental stage

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -4031,6 +4031,7 @@ static int snap_cow_thread(void *data){
 			elastio_snap_bio_endio(bio, (ret)? wrap_err_io(dev) : 0);
 		}else{
 			if(is_failed){
+				atomic64_inc(&dev->sd_processed_cnt);
 				bio_free_clone(bio);
 				continue;
 			}


### PR DESCRIPTION
Update `sd_processed_cnt` counter in case of error condition