### PR TITLE
[RA-6331] fixed redhat specific kernel bio req ops

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -4260,6 +4260,9 @@ static int snap_trace_bio(struct snap_device *dev, struct bio *bio){
 	sector_t start_sect, end_sect;
 	unsigned int bytes, pages;
 	int max_sectors;
+#if defined HAVE_ENUM_REQ_OPF || defined HAVE_ENUM_REQ_OP
+	unsigned int bio_op_idx = 0;
+#endif
 
 	//if we don't need to cow this bio or if the snapshot is in the failed state,
 	//e.g. physical memory usage has exceeded threshold or COW file state is failed,
@@ -4293,7 +4296,10 @@ static int snap_trace_bio(struct snap_device *dev, struct bio *bio){
 	}
 
 #if defined HAVE_ENUM_REQ_OPF || defined HAVE_ENUM_REQ_OP
-	dev->sd_bio_stats_traced[bio_op(bio)]++;
+	bio_op_idx = bio_op(bio);
+	if (likely(bio_op_idx < BIO_STATS_MAX_ELEMENTS)) {
+		dev->sd_bio_stats_traced[bio_op_idx]++;
+	}
 #endif
 
 	//the cow manager works in 4096 byte blocks, so read clones must also be 4096 byte aligned
@@ -4382,9 +4388,15 @@ static int inc_trace_bio(struct snap_device *dev, struct bio *bio){
 	sector_t start_sect = 0, end_sect = bio_sector(bio);
 	bio_iter_t iter;
 	bio_iter_bvec_t bvec;
+#if defined HAVE_ENUM_REQ_OPF || defined HAVE_ENUM_REQ_OP
+	unsigned int bio_op_idx = 0;
+#endif
 
 #if defined HAVE_ENUM_REQ_OPF || defined HAVE_ENUM_REQ_OP
-	dev->sd_bio_stats_traced[bio_op(bio)]++;
+	bio_op_idx = bio_op(bio);
+	if (likely(bio_op_idx < BIO_STATS_MAX_ELEMENTS)) {
+		dev->sd_bio_stats_traced[bio_op_idx]++;
+	}
 #endif
 
 	if (!test_bit(COW_ON_BDEV, &dev->sd_cow_state)){
@@ -4451,6 +4463,9 @@ static MRF_RETURN_TYPE tracing_mrf(struct request_queue *q, struct bio *bio){
 	int i, ret = 0;
 	struct snap_device *dev;
 	make_request_fn *orig_mrf = NULL;
+#if defined HAVE_ENUM_REQ_OPF || defined HAVE_ENUM_REQ_OP
+	unsigned int bio_op_idx = 0;
+#endif
 
 	MAYBE_UNUSED(ret);
 	smp_rmb();
@@ -4458,7 +4473,10 @@ static MRF_RETURN_TYPE tracing_mrf(struct request_queue *q, struct bio *bio){
 		if(!dev || test_bit(UNVERIFIED, &dev->sd_state)) continue;
 
 #if defined HAVE_ENUM_REQ_OPF || defined HAVE_ENUM_REQ_OP
-		dev->sd_bio_stats_total[bio_op(bio)]++;
+		bio_op_idx = bio_op(bio);
+		if (likely(bio_op_idx < BIO_STATS_MAX_ELEMENTS)) {
+			dev->sd_bio_stats_total[bio_op_idx]++;
+		}
 #endif
 
 		if (!tracer_matches_bio(dev, bio)) continue;

--- a/src/main.c
+++ b/src/main.c
@@ -1068,7 +1068,8 @@ struct tracing_ops {
 #ifdef REQ_OP_LAST
 #define BIO_STATS_MAX_ELEMENTS REQ_OP_LAST
 #else
-#define BIO_STATS_MAX_ELEMENTS 64
+// NOTE: HT: last 8 bits are used for operation, different distros have different implementations for it
+#define BIO_STATS_MAX_ELEMENTS 256
 #endif
 
 struct cow_section{


### PR DESCRIPTION
- [x] tested on dev Ubuntu 24 machine
- [x] tested on redhat QA machine

## For Reviewers

It looks like that RedHat uses a modified version (at least it does not match what we see inside the bootlin elixir browser) of the kernel. The request operations are defined in the following way:
```c
// linux/blk_stats.h
...
enum rq_flag_bits {
        /* common flags */
        __REQ_WRITE,            /* not set, read. set, write */
...
        __REQ_MQ_INFLIGHT,      /* track inflight for MQ */
#ifdef __GENKSYMS__
        __REQ_NO_TIMEOUT,       /* requests may never expire */
#else
        __REQ_STATS,
#endif
        __REQ_NR_BITS,          /* stops here */
};

#define REQ_WRITE               (1ULL << __REQ_WRITE)
#define REQ_FAILFAST_DEV        (1ULL << __REQ_FAILFAST_DEV)
...

#define REQ_RAHEAD              (1ULL << __REQ_RAHEAD)
#define REQ_THROTTLED           (1ULL << __REQ_THROTTLED)
...
#define REQ_HASHED              (1ULL << __REQ_HASHED)
#define REQ_MQ_INFLIGHT         (1ULL << __REQ_MQ_INFLIGHT)
/* IO stats tracking on */
#define REQ_STATS               (1ULL << __REQ_STATS)

enum req_op {
        REQ_OP_READ,
        REQ_OP_WRITE            = REQ_WRITE,
        REQ_OP_DISCARD          = REQ_DISCARD,
        REQ_OP_WRITE_SAME       = REQ_WRITE_SAME,
};
...
``` 

The `bio_op` simply gets the operation bits:
```c
// linux/blk_stats.h
static inline int op_from_rq_bits(u64 flags)
{
        if (flags & REQ_OP_DISCARD)
                return REQ_OP_DISCARD;
        else if (flags & REQ_OP_WRITE_SAME)
                return REQ_OP_WRITE_SAME;
        else if (flags & REQ_OP_WRITE)
                return REQ_OP_WRITE;
        else
                return REQ_OP_READ;
}

// linux/bio.h
#define bio_op(bio)                             (op_from_rq_bits((bio)->bi_rw))
```

`bi_rw` top bits are the priority where the bottom bits are the actual operation. In theory the prio bits should occupy the first 48bits... but all references use max 8 bits for the request operation, I'm assuming the padding is reserved for later versions (I have checked kernel versions from 3.0 to 6).

The reason for `sd_refs` being incremented was the overflow. Operation with value `64+` (for example `128`, which BTW was `REQ_OP_DISCARD (1 << 7)`) was used inside the `64` sized array which indirectly increments the reference counter. The field `sd_bio_stats_total` is (almost) right above the `sd_refs`.

Since REQ_OP_DISCARD = 128 = (1 << 7) is the same size as `sd_bio_stats_total` (64 by default) and `sd_bio_stats_traced` (64 by default) it directly jumps to `sd_refs`.