### PR TITLE
[RA-6417] Implement driver support for the Linux kernel v6.15

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -25,6 +25,8 @@ ifeq ($(NETLINK_DEBUG),y)
 EXTRA_CFLAGS += -DNETLINK_DEBUG
 endif
 
+ccflags-y += $(EXTRA_CFLAGS)
+
 FEATURE_TEST_BUILD_DIR := configure-tests/feature-tests/build
 
 default:

--- a/src/configure-tests/feature-tests/Makefile
+++ b/src/configure-tests/feature-tests/Makefile
@@ -13,6 +13,8 @@ BUILDDIR ?= $(PWD)/build/$(OBJ)
 BUILDDIR_MAKEFILE ?= $(PWD)/build/$(OBJ)/Makefile
 BUILDDIR_SOURCE ?= $(PWD)/build/$(OBJ)/$(SRC)
 
+ccflags-y += $(EXTRA_CFLAGS)
+
 default: $(BUILDDIR_MAKEFILE)
 	$(MAKE) -C $(KDIR) M=$(BUILDDIR) src=$(PWD) modules
 


### PR DESCRIPTION
Explicit EXTRA_CFLAGS transfer to Kbuild