### PR TITLE
[RA-6679] support v6.16+

### DIFF
--- a/src/configure-tests/feature-tests/freeze_super_3.c
+++ b/src/configure-tests/feature-tests/freeze_super_3.c
@@ -1,10 +1,10 @@
 // SPDX-License-Identifier: GPL-2.0-only
 
 /*
- * Copyright (C) 2024 Axcient Software Inc.
+ * Copyright (C) 2025 Axcient Software Inc.
  */
 
-// kernel_version < 6.6
+// kernel_version >= 6.16
 
 #include "includes.h"
 MODULE_LICENSE("GPL");

--- a/src/configure-tests/feature-tests/freeze_super_3.c
+++ b/src/configure-tests/feature-tests/freeze_super_3.c
@@ -1,0 +1,15 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+/*
+ * Copyright (C) 2024 Axcient Software Inc.
+ */
+
+// kernel_version < 6.6
+
+#include "includes.h"
+MODULE_LICENSE("GPL");
+
+static inline void dummy(void){
+    struct super_block *sb;
+	freeze_super(sb, 0, NULL);
+}

--- a/src/main.c
+++ b/src/main.c
@@ -4753,18 +4753,23 @@ static int __tracer_transition_tracing(struct snap_device *dev, struct block_dev
 		//freeze and sync block device
 		LOG_DEBUG("freezing '%s'", bdev_name);
 
-#ifndef HAVE_FREEZE_SUPER_2
+#if defined(HAVE_FREEZE_SUPER_2)
+		if (origsb->s_op->freeze_super)
+			ret = origsb->s_op->freeze_super(origsb, FREEZE_HOLDER_KERNEL);
+		else
+			ret = freeze_super(origsb, FREEZE_HOLDER_KERNEL);
+#elif defined(HAVE_FREEZE_SUPER_3)
+		if (origsb->s_op->freeze_super)
+			ret = origsb->s_op->freeze_super(origsb, FREEZE_HOLDER_KERNEL, NULL);
+		else
+			ret = freeze_super(origsb, FREEZE_HOLDER_KERNEL, NULL);
+#else
 #ifdef HAVE_FREEZE_SUPER_PTR
 		if (origsb->s_op->freeze_super)
 			ret = origsb->s_op->freeze_super(origsb);
 		else
 #endif
 			ret = freeze_super(origsb);
-#else
-		if (origsb->s_op->freeze_super)
-			ret = origsb->s_op->freeze_super(origsb, FREEZE_HOLDER_KERNEL);
-		else
-			ret = freeze_super(origsb, FREEZE_HOLDER_KERNEL);
 #endif
 
 		/* ret = elastio_snap_freeze_bdev(bdev, &sb); */
@@ -4825,18 +4830,23 @@ static int __tracer_transition_tracing(struct snap_device *dev, struct block_dev
 	if(origsb){
 		//thaw the block device
 		LOG_DEBUG("thawing '%s'", bdev_name);
-#ifndef HAVE_FREEZE_SUPER_2
+#if defined(HAVE_FREEZE_SUPER_2)
+		if (origsb->s_op->thaw_super)
+			ret = origsb->s_op->thaw_super(origsb, FREEZE_HOLDER_KERNEL);
+		else
+			ret = thaw_super(origsb, FREEZE_HOLDER_KERNEL);
+#elif defined(HAVE_FREEZE_SUPER_3)
+		if (origsb->s_op->thaw_super)
+			ret = origsb->s_op->thaw_super(origsb, FREEZE_HOLDER_KERNEL, NULL);
+		else
+			ret = thaw_super(origsb, FREEZE_HOLDER_KERNEL, NULL);
+#else
 #ifdef HAVE_FREEZE_SUPER_PTR
 		if (origsb->s_op->thaw_super)
 			ret = origsb->s_op->thaw_super(origsb);
 		else
 #endif
 			ret = thaw_super(origsb);
-#else
-		if (origsb->s_op->thaw_super)
-			ret = origsb->s_op->thaw_super(origsb, FREEZE_HOLDER_KERNEL);
-		else
-			ret = thaw_super(origsb, FREEZE_HOLDER_KERNEL);
 #endif
 		/* ret = elastio_snap_thaw_bdev(bdev, sb); */
 		if(ret){


### PR DESCRIPTION
- [x] tested on a development machine (kernel: 6.16, distro: RH)

## For Reviewers

Starting from v6.16 `freeze_super` and `thaw_super` accept an additional argument `freeze_owner`. It can be set to `NULL` to mimic the default behavior, but it can also be used to tell the system who is doing the locking.

A possible change would be:
```c
// CURRENT: ret = freeze_super(origsb, FREEZE_HOLDER_KERNEL, NULL);
ret = freeze_super(origsb, FREEZE_HOLDER_KERNEL, "elastio-snap");
```