### PR TITLE
Revert "[RA-4567] Affected files are found on Ubuntu (#86)"

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -2311,10 +2311,6 @@ static int file_allocate(struct cow_manager *cm, struct file *f, uint64_t offset
 	}
 
 out:
-	ret = vfs_fsync(f, 0);
-	if (ret) {
-		LOG_ERROR(ret, "could not sync the file, but let's continue");
-	}
 
 	if(page_buf) free_page((unsigned long)page_buf);
 	if(abs_path) kfree(abs_path);
@@ -4746,8 +4742,6 @@ static int __tracer_transition_tracing(struct snap_device *dev, struct block_dev
 	elastio_snap_bdevname(bdev, bdev_name);
 
 	if(origsb){
-		LOG_DEBUG("force syncing the disk '%s'", bdev_name);
-		sync_filesystem(origsb);
 		drop_super(origsb);
 
 		//freeze and sync block device

--- a/tests/test_update_image.py
+++ b/tests/test_update_image.py
@@ -26,7 +26,6 @@ class TestUpdateImage(DeviceTestCase):
     def tearDown(self):
         util.test_track(self._testMethodName, started=False)
 
-    @unittest.skipIf(os.getenv('TEST_DEVICES') and 'jessie' in open('/etc/os-release', "r").read(), "Disabled for Debian 8 with disks")
     def test_update_sequence(self):
         iterations = 25
         file_name = "testfile"


### PR DESCRIPTION
This reverts commit 7733818f11d4b7b1d8dd60714a6598496fdf1a4b.