### PR TITLE
[RA-7078] Integrate Fedora 44 with elastio-snap CI tests

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -63,7 +63,7 @@ pipeline
 							'alma8', 'alma9',
 							'ubuntu1804', 'ubuntu2004', 'ubuntu2204', 'ubuntu2404',
 							'rhel7', 'rhel8', 'rhel9',
-							'fedora43'
+							'fedora44'
 					}
 				}
 				agent {
@@ -73,7 +73,7 @@ pipeline
 				{
 					stage('Update kernel')
 					{
-						when { expression { env.DISTRO == 'fedora43' } }
+						when { expression { env.DISTRO == 'fedora44' } }
 						steps
 						{
 							updateKernelWithReboot()

--- a/dist/elastio-snap.spec
+++ b/dist/elastio-snap.spec
@@ -651,7 +651,7 @@ rm -rf %{buildroot}
 
 
 %changelog
-* Thu Dec 2025 Stanislav Barantsev <sbarantsev@axcient.com> - 0.12.10
+* Thu Dec 11 2025 Stanislav Barantsev <sbarantsev@axcient.com> - 0.12.10
  - [RA-6679] support v6.16+
  - [RA-6863] Restore elastio-shap build pipeline
  - [RA-6798] Add Debian 13


### PR DESCRIPTION
Added Fedora 44, fixed data in the spec file