### PR TITLE
[RA-7658] NVME drives and kernel 6.17

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -990,7 +990,7 @@ static void bio_free_pages(struct bio *bio){
  * instead of 6 as in other kernels, where this enum is present. And it doesn't have defined REQ_OP_BITS, which could
  * be defined and equal to the 2 bits.
  */
-#define __ELASTIO_SNAP_PASSTHROUGH 28	// set as the last flag bit
+#define __ELASTIO_SNAP_PASSTHROUGH (__REQ_NR_BITS)	// set as the last flag bit
 #else
 // set as an unused flag in versions older than 4.8
 // set as an unused opcode bit in kernels newer than 4.9

--- a/src/main.c
+++ b/src/main.c
@@ -979,7 +979,7 @@ static void bio_free_pages(struct bio *bio){
 #define bio_last_sector(bio) (bio_sector(bio) + (bio_size(bio) / SECTOR_SIZE))
 
 /* don't perform COW operation */
-#if defined HAVE_ENUM_REQ_OP && defined REQ_OP_BITS
+#if defined HAVE_ENUM_REQ_OP && defined REQ_OP_BITS && defined BIO_OP_SHIFT
 //#if LINUX_VERSION_CODE >= KERNEL_VERSION(4,8,0) && LINUX_VERSION_CODE < KERNEL_VERSION(4,10,0)
 /* special case for deb9's 4.9 train
  * Bit 30 conflicts with struct bio's bi_opf opcode bitfield, which occupies the top 3 bits of the member. If we set
@@ -989,10 +989,11 @@ static void bio_free_pages(struct bio *bio){
  * Note: CentOS 7 has enum req_op starting from the version 7.4, kernel 3.10.0-693. But this enum has just 4 values
  * instead of 6 as in other kernels, where this enum is present. And it doesn't have defined REQ_OP_BITS, which could
  * be defined and equal to the 2 bits.
- *
- * Note: For versions newer 4.9 low REQ_OP_BITS occupies to opcode, and first enum for flags declared as __REQ_FAILFAST_DEV = REQ_OP_BITS.
  */
-#define __ELASTIO_SNAP_PASSTHROUGH ( (__REQ_FAILFAST_DEV == REQ_OP_BITS) ? __REQ_NR_BITS : 28)
+#define __ELASTIO_SNAP_PASSTHROUGH 28
+#elif defined HAVE_ENUM_REQ_OP && defined REQ_OP_BITS
+//#if LINUX_VERSION_CODE >= KERNEL_VERSION(4,10,0)
+#define __ELASTIO_SNAP_PASSTHROUGH __REQ_NR_BITS
 #else
 // set as an unused flag in versions older than 4.8
 #define __ELASTIO_SNAP_PASSTHROUGH 30

--- a/src/main.c
+++ b/src/main.c
@@ -989,11 +989,12 @@ static void bio_free_pages(struct bio *bio){
  * Note: CentOS 7 has enum req_op starting from the version 7.4, kernel 3.10.0-693. But this enum has just 4 values
  * instead of 6 as in other kernels, where this enum is present. And it doesn't have defined REQ_OP_BITS, which could
  * be defined and equal to the 2 bits.
+ *
+ * Note: For versions newer 4.9 low REQ_OP_BITS occupies to opcode, and first enum for flags declared as __REQ_FAILFAST_DEV = REQ_OP_BITS.
  */
-#define __ELASTIO_SNAP_PASSTHROUGH (__REQ_NR_BITS)	// set as the last flag bit
+#define __ELASTIO_SNAP_PASSTHROUGH ( (__REQ_FAILFAST_DEV == REQ_OP_BITS) ? __REQ_NR_BITS : 28)
 #else
 // set as an unused flag in versions older than 4.8
-// set as an unused opcode bit in kernels newer than 4.9
 #define __ELASTIO_SNAP_PASSTHROUGH 30
 #endif
 #if (__GNUC__ > 4)

--- a/src/main.c
+++ b/src/main.c
@@ -996,6 +996,9 @@ static void bio_free_pages(struct bio *bio){
 // set as an unused opcode bit in kernels newer than 4.9
 #define __ELASTIO_SNAP_PASSTHROUGH 30
 #endif
+#if (__GNUC__ > 4)
+static_assert(__ELASTIO_SNAP_PASSTHROUGH < 32, "Not enough bits for mark BIO at flags");
+#endif
 #define ELASTIO_SNAP_PASSTHROUGH (1ULL << __ELASTIO_SNAP_PASSTHROUGH)
 
 #define ELASTIO_SNAP_DEFAULT_SNAP_DEVICES 24

--- a/src/main.c
+++ b/src/main.c
@@ -998,7 +998,7 @@ static void bio_free_pages(struct bio *bio){
 #define __ELASTIO_SNAP_PASSTHROUGH 30
 #endif
 #if (__GNUC__ > 4)
-static_assert(__ELASTIO_SNAP_PASSTHROUGH < 32, "Not enough bits for mark BIO at flags");
+_Static_assert(__ELASTIO_SNAP_PASSTHROUGH < 32, "Not enough bits for mark BIO at flags");
 #endif
 #define ELASTIO_SNAP_PASSTHROUGH (1ULL << __ELASTIO_SNAP_PASSTHROUGH)
 


### PR DESCRIPTION
There are such kind of errors:
`[ 3282.377753] invalid error, dev nvme0n1, sector 15994880 op 0x1:(WRITE) flags 0x10000000 `
0x10000000 = 1<<28 == ELASTIO_SNAP_PASSTHROUGH
Root cause in that some new operation  was added to req_flag_bits (include/linux/blk_types.h)
